### PR TITLE
chore: add .gitattributes to exclude vendor files from GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Mark vendor directories as vendored for GitHub language statistics
+vendor/* linguist-vendored
+
+# Mark test fixtures as vendored
+test/__fixtures__/* linguist-vendored


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` file to mark `vendor/*` and `test/__fixtures__/*` as vendored
- Improves accuracy of GitHub language statistics by excluding third-party and test fixture files

## Test plan
- [x] Verify `.gitattributes` file is properly formatted
- [ ] After merge, check that GitHub language statistics exclude vendor files

🤖 Generated with [Claude Code](https://claude.ai/code)